### PR TITLE
Improve simulation iteration performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15590,6 +15590,14 @@
       "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "dev": true
     },
+    "random-normal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-normal/-/random-normal-1.0.0.tgz",
+      "integrity": "sha1-2qC1+kyusVloF4M48qxS5jpuRok=",
+      "requires": {
+        "object-assign": "^4.0.1"
+      }
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "moment": "^2.24.0",
     "natural-spline-interpolator": "^1.0.2",
     "prop-types": "^15.7.2",
+    "random-normal": "^1.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-github-btn": "^1.1.1",

--- a/src/components/application.js
+++ b/src/components/application.js
@@ -222,7 +222,7 @@ class App extends Component {
         setStats(simulationState.stats);
         setParametersChanges(simulationState.parametersChanges);
       }
-    }, 100);
+    }, 25);
   }
 
   handleResetParameters = () => {


### PR DESCRIPTION
This PR improves the simulation performance by converting some `filter` calls to for loops, caching some values that were being calculated multiple times and changing the sampling method used for sampling truncated normal distributions to a more efficient one.