### PR TITLE
Improve initial cases infection day distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Covid-19 Simulator allows anyone to simulate how the numbers of covid-19 can evo
 
 - **Initial dead**: Number of individuals assigned the dead state at the start of the simulation. It is assumed that all dead are reported, so this number corresponds to both the true and reported dead cases.
 
-- **Transmissibility**: The transmissibility rate, reproduction number or R0 of the virus. Represents how many people each infected person will infect, on average, if no contention measures are applied.
+- **Transmissibility**: The transmissibility rate of the virus. Determines how contagious is the virus on a totally susceptible population where there are no fighting measures in place. 
 
 - **Under reporting factor**: The ratio between the number of cases reported and true number of cases.
 

--- a/src/components/application.js
+++ b/src/components/application.js
@@ -44,10 +44,10 @@ const theme = createMuiTheme({
 
 const defaultSimulationParameters = {
   population: 10000000,
-  daysSinceFirstDiagnostic: 0,
-  initialReportedInfected: 1000,
-  initialReportedRecovered: 1000,
-  initialDead: 100,
+  daysSinceFirstDiagnostic: 30,
+  initialReportedInfected: 7500,
+  initialReportedRecovered: 50,
+  initialDead: 150,
   averageRecoveringDays: 20,
   averageDyingDays: 7,
   averageDiagnosticDays: 6,

--- a/src/components/parameters-form.js
+++ b/src/components/parameters-form.js
@@ -54,14 +54,14 @@ const schema = {
       component: Slider
     },
     transmissibility: {
-      description: 'The transmissibility rate, reproduction number or R0 of the virus. Represents how many people each infected person will infect, on average, if no contention measures are applied.',
+      description: 'The transmissibility rate of the virus. Determines how contagious is the virus on a totally susceptible population where there are no fighting measures in place.',
       type: 'integer',
       minimum: 0,
       maximum: 30,
       component: Slider
     },
     underReportingFactor: {
-      description: 'The ratio between the number of cases reported and true number of cases.',
+      description: 'The ratio between the number of cases reported and true number of cases. This ratio is respected in the beginning of the simulation, but it can change due to the different dynamics acting on the numbers.',
       type: 'integer',
       minimum: 1,
       maximum: 100,

--- a/src/components/parameters-form.js
+++ b/src/components/parameters-form.js
@@ -28,7 +28,7 @@ const schema = {
     daysSinceFirstDiagnostic: {
       description: 'Number of days since the epidemic started. This does not change the simulation results, it just modifies the days displayed on the x axis on the charts.',
       type: 'integer',
-      minimum: 0,
+      minimum: 1,
       maximum: 300,
       component: Slider
     },

--- a/src/simulation/index.js
+++ b/src/simulation/index.js
@@ -183,7 +183,7 @@ function calculateStats() {
  */
 
 function virtualizeRawStats(stats) {
-  const { daysSinceFirstDiagnostic, subSamplingFactor } = simulationParameters;
+  const { subSamplingFactor } = simulationParameters;
 
   return stats.map(dayStat => {
     const {
@@ -201,7 +201,7 @@ function virtualizeRawStats(stats) {
     } = dayStat;
 
     return {
-      day: daysSinceFirstDiagnostic + day,
+      day,
       reportedInfected: reportedInfected / subSamplingFactor,
       reportedRecovered: reportedRecovered / subSamplingFactor,
       reportedTotalInfected: reportedTotalInfected / subSamplingFactor,
@@ -240,7 +240,7 @@ function sampleDay(distributionValues, distributionWeights, mean, stdev, truncat
 
 function initialize() {
   const {
-    averageRecoveringDays,
+    daysSinceFirstDiagnostic,
     initialDead,
     initialReportedInfected,
     initialReportedRecovered,
@@ -249,11 +249,10 @@ function initialize() {
   } = simulationParameters;
 
   studyPopulation = [];
-  simulationState = { ...initialSimulationState };
+  simulationState = { ...initialSimulationState, day: daysSinceFirstDiagnostic };
 
-  const daysBackDiagnosticDistribution = distributions.Normal(averageRecoveringDays, averageRecoveringDays / 5);
-  const daysList = range(100);
-  const daysBackDistributionWeights = daysList.map(day => 1 - daysBackDiagnosticDistribution.cdf(day));
+  const daysList = range(daysSinceFirstDiagnostic + 1).slice(1);
+  const daysBackDistributionWeights = daysList.map(day => Math.exp(Math.log(initialReportedInfected) / daysSinceFirstDiagnostic * -(day - daysSinceFirstDiagnostic)));
 
   for (let i = 0; i < upsampleSizeRounded(population); i++) {
     studyPopulation.push({
@@ -266,7 +265,7 @@ function initialize() {
     studyPopulation[i].healthState = healthState.INFECTED;
     studyPopulation[i].infectionState = infectionState.DIAGNOSED;
     studyPopulation[i].willBeDiagnosed = true;
-    studyPopulation[i].infectedDay = -weighted.select(daysList, daysBackDistributionWeights);
+    studyPopulation[i].infectedDay = -weighted.select(daysList, daysBackDistributionWeights) + simulationState.day;
   }
 
   let lastIndex = upsampleSizeRounded(initialReportedInfected);
@@ -275,7 +274,7 @@ function initialize() {
   for (let i = lastIndex; i < lastIndex + upsampleSizeRounded(totalNonDiagnosedInfected); i++) {
     studyPopulation[i].healthState = healthState.INFECTED;
     studyPopulation[i].infectionState = infectionState.UNDETECTED;
-    studyPopulation[i].infectedDay = -weighted.select(daysList, daysBackDistributionWeights);
+    studyPopulation[i].infectedDay = -weighted.select(daysList, daysBackDistributionWeights) + simulationState.day;
   }
 
   lastIndex += upsampleSizeRounded(totalNonDiagnosedInfected);
@@ -303,7 +302,7 @@ function initialize() {
 
   lastIndex += upsampleSizeRounded(initialDead);
 
-  createFates(studyPopulation.filter(person => person.healthState === healthState.INFECTED && person.infectionState === infectionState.UNDETECTED), true);
+  createFates(studyPopulation.filter(person => person.healthState === healthState.INFECTED && person.infectionState === infectionState.UNDETECTED), false);
 
   simulationStats = [calculateStats()];
 

--- a/src/simulation/index.js
+++ b/src/simulation/index.js
@@ -322,7 +322,7 @@ function initialize() {
  */
 
 function infect() {
-  const { averageRecoveringDays, initialTransmissionBoost, measuresSeverity, population, transmissibility } = simulationParameters;
+  const { initialTransmissionBoost, measuresSeverity, population, transmissibility } = simulationParameters;
   let susceptibleCount = 0;
   let infectedFreeCount = 0;
   let allAffectedCount = 0;
@@ -342,7 +342,7 @@ function infect() {
   const healthyPopulationRatio = susceptibleCount / upsampleSize(population);
   const initialContagionEffect = allAffectedCount => (initialTransmissionBoost - 1) * Math.exp(-(allAffectedCount * 300 / upsampleSize(population))) + 1;
   const contagionFactor = (1 - measuresSeverity) * transmissibility * initialContagionEffect(allAffectedCount);
-  const toBeInfectedCount = infectedFreeCount * healthyPopulationRatio * contagionFactor * (1 / averageRecoveringDays);
+  const toBeInfectedCount = infectedFreeCount * healthyPopulationRatio * contagionFactor * 0.05;
 
   if (log.getLevel() <= log.levels.DEBUG) {
     log.debug('Infected before:', studyPopulation.filter(person => person.healthState === healthState.INFECTED).length);


### PR DESCRIPTION
This PR improves the assignment of the infection day of starting infected, making the day follow an exponential distribution decreasing from the present to the past.

It also slightly changes the semantics of the transmissibility making it independent on the recovering days.