### PR TITLE
Fix inadequate distribution weights

### DIFF
--- a/src/simulation/index.js
+++ b/src/simulation/index.js
@@ -231,7 +231,17 @@ function sampleDay(distributionValues, distributionWeights, mean, stdev, truncat
     return day;
   }
 
-  return weighted.select(distributionValues.slice(truncationValue), distributionWeights.slice(truncationValue));
+  let day;
+
+  try {
+    day = weighted.select(distributionValues.slice(truncationValue), distributionWeights.slice(truncationValue));
+  } catch (error) {
+    if (error instanceof RangeError) {
+      day = weighted.select(distributionValues.slice(truncationValue), distributionWeights.slice(truncationValue).map(() => 1));
+    }
+  }
+
+  return day;
 }
 
 /**


### PR DESCRIPTION
This PR fixes a bug when that would come up when calling `weighted.select` with distributions of all 0 values.