### PR TITLE
Add ratio of diagnosed cases parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Covid-19 Simulator allows anyone to simulate how the numbers of covid-19 can evo
 
 - **Transmissibility**: The transmissibility rate of the virus. Determines how contagious is the virus on a totally susceptible population where there are no fighting measures in place.
 
-- **Under reporting factor**: The ratio between the number of cases reported and true number of cases.
+- **Ratio of cases diagnosed**: The ratio between new cases that will be diagnosed and the total amount of new cases.
+
+- **Under reporting factor**: The initial ratio between the number of cases reported and true number of cases. This ratio is respected in the beginning of the simulation, but it can change due to the different dynamics acting on the numbers.
 
 - **Measures severity**: This parameter can be roughtly interpreted as the percentage of normal interactions that are being limited by the contention measures in place.
 

--- a/src/components/application.js
+++ b/src/components/application.js
@@ -56,6 +56,7 @@ const defaultSimulationParameters = {
   averageDyingDays: 7,
   averageDiagnosticDays: 6,
   transmissibility: 3,
+  ratioCasesDiagnosed: 0.4,
   underReportingFactor: 10,
   measuresSeverity: 0,
   initialTransmissionBoost: 5,
@@ -170,12 +171,9 @@ class App extends Component {
         'underReportingFactor',
         'measuresSeverity',
         'initialTransmissionBoost',
+        'ratioCasesDiagnosed',
         'trueDeathRate'
       ]);
-
-      console.log('parameters: ', parameters);
-      console.log('defaultSimulationParameters: ', defaultSimulationParameters);
-      console.log('allowedDefaultParameters: ', allowedDefaultParameters);
 
       const parametersToSet = {
         ...parameters,

--- a/src/components/parameters-form.js
+++ b/src/components/parameters-form.js
@@ -60,8 +60,16 @@ const schema = {
       maximum: 30,
       component: Slider
     },
+    ratioCasesDiagnosed: {
+      description: 'The ratio between new cases that will be diagnosed and the total amount of new cases.',
+      type: 'integer',
+      minimum: 0,
+      maximum: 1,
+      step: 0.01,
+      component: Slider
+    },
     underReportingFactor: {
-      description: 'The ratio between the number of cases reported and true number of cases. This ratio is respected in the beginning of the simulation, but it can change due to the different dynamics acting on the numbers.',
+      description: 'The initial ratio between the true number of cases and the number of cases reported. This ratio is respected in the beginning of the simulation, but it can change due to the different dynamics acting on the numbers.',
       type: 'integer',
       minimum: 1,
       maximum: 100,
@@ -275,7 +283,18 @@ class ParametersForm extends Component {
               sm={6}
               xl={2}
             >
-              <AutoField name={'underReportingFactor'} />
+              <AutoField name={'ratioCasesDiagnosed'} />
+            </Col>
+
+            <Col
+              lg={3}
+              sm={6}
+              xl={2}
+            >
+              <AutoField
+                disabled={!isStopped}
+                name={'underReportingFactor'}
+              />
             </Col>
 
             <Col


### PR DESCRIPTION
This PR adds a new parameter "ratio of diagnosed cases". Previously this ratio was determined by the under reporting factor. However this is not correct, since the initial under reporting factor is inflated in relation to the ratio of diagnosed cases due to the time between infection and diagnose. So they are different values that must be set separately.